### PR TITLE
Updated and polished Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM node:10.15.3
+FROM node:alpine
 
 WORKDIR /broadlink-mqtt-bridge
-
 COPY . .
-
+RUN apk --update add git less openssh && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm /var/cache/apk/*
 RUN npm install
 
 ENTRYPOINT ["npm", "start"]
 
-VOLUME [ "/broadlink-mqtt-bridge/config/local.json", "/broadlink-mqtt-bridge/commands" ]
+VOLUME [ "/broadlink-mqtt-bridge/config", "/broadlink-mqtt-bridge/commands" ]
 
-EXPOSE 3000
+EXPOSE 3000 3001

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build --no-cache=true -t broadlink-mqtt-bridge:latest .


### PR DESCRIPTION
I gave some love to the existing Dockerfile:

- updated base image from 10.15.3 to latest node image
- switched from Debian based image to Alpine image (size goes down from over 900 MiB to ~180 MiB)
- fixed wrong volume mapping (local.json should not be a directory), rather config/default.json should be adapted
- exposed also port 3001 for logging

I also added a docker_build shell script. Not really necessary, but it saves precious typing time.

Tried and tested on my local Intel NUC.